### PR TITLE
Allow relative paths as argument for wp-boilerplate-version.sh

### DIFF
--- a/wp-boilerplate-version.sh
+++ b/wp-boilerplate-version.sh
@@ -10,7 +10,8 @@ if [ "$1" == "-h" ] || [ $# -eq 0 ]; then
 	echo "-h: this help"
 	exit 0
 fi
-slug=`basename $1`
+
+slug=`basename $(readlink -f $1)`
 
 LINE=`sed -n '/Stable tag: /{=}' README.txt`
 sed -i "${LINE}s/.*/Stable tag: ${2}/" README.txt


### PR DESCRIPTION
## Background
If you run the `wp-boilerplate-version.sh` script from the plugin directory and don't want to pass it the absolute path to the directory you're in, it comes handy to pass a `.` as first parameter.

## Description
Unfortunately, if you pass `.` as the first parameter to the script, it does not work. My edit allows for resolution of _symbolic links_ and _relative paths_, like the one in the example.

## Going further
This is still a bad solution, in my opinion. If you're already in a WordPress Plugin Boilerplate Powered project, you should not specify the path to it in order for the script to work. So it would be better if the path were an optional parameter defaulting to the current working directory.