### PR TITLE
Indentation-independent version replacement

### DIFF
--- a/wp-boilerplate-version.sh
+++ b/wp-boilerplate-version.sh
@@ -16,8 +16,7 @@ slug=`basename $(readlink -f $1)`
 LINE=`sed -n '/Stable tag: /{=}' README.txt`
 sed -i "${LINE}s/.*/Stable tag: ${2}/" README.txt
 
-LINE=`sed -n '/    const VERSION = /{=}' public/class-${slug}.php`
-sed -i "${LINE}s/.*/    const VERSION = '${2}';/" public/class-${slug}.php
+sed -i "s/const VERSION = '.*';/const VERSION = '${2}';/" public/class-${slug}.php
 
 LINE=`sed -n '/ * Version:/{=}' ${slug}.php`
 sed -i "${LINE}s/.*/ * Version:           ${2}/" ${slug}.php


### PR DESCRIPTION
If you change the indentation of the `public/class-${slug}.php` file, the wp-boilerplate-version.sh script breaks the file itself, replacing **all** its content with the string `const VERSION = '<version>';`.

The fix proposed works around this issue replacing only the text in that line, without caring about how many spaces or tabs there are at the beginning and without breaking the entire file.